### PR TITLE
Fix lifecycle-mapping plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1448,7 +1448,7 @@
 						<plugin>
 							<groupId>org.eclipse.m2e</groupId>
 							<artifactId>lifecycle-mapping</artifactId>
-							<version>${lifecycle-mapping.version}</version>
+							<version>${lifecycle-mapping-plugin.version}</version>
 							<configuration>
 								<lifecycleMappingMetadata>
 									<pluginExecutions>


### PR DESCRIPTION
The version was referring to a non-existing property.