### PR TITLE
Update Kotlin and Dokka versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1062,14 +1062,14 @@
 			<properties>
 				<kotlin.compiler.incremental>true</kotlin.compiler.incremental>
 				<kotlin.compiler.jvmTarget>${scijava.jvm.version}</kotlin.compiler.jvmTarget>
-				<kotlin.version>1.1.2-5</kotlin.version>
+				<kotlin.version>1.2.41</kotlin.version>
 				<kotlin-maven-plugin.version>${kotlin.version}</kotlin-maven-plugin.version>
-				<dokka-maven-plugin.version>0.9.14</dokka-maven-plugin.version>
+				<dokka-maven-plugin.version>0.9.16</dokka-maven-plugin.version>
 			</properties>
 			<dependencies>
 				<dependency>
 					<groupId>org.jetbrains.kotlin</groupId>
-					<artifactId>kotlin-stdlib-jre8</artifactId>
+					<artifactId>kotlin-stdlib-jdk8</artifactId>
 					<version>${kotlin.version}</version>
 				</dependency>
 			</dependencies>


### PR DESCRIPTION
This PR:
* updates Kotlin to the current version (1.2.41)
* updates Dokka to the current version (0.9.16)
* changes the deprecated kotlin-stdlib-jre8 (which causes issues with the JDK9 module system) to kotlin-stdlib-jdk8