### PR TITLE
Add JaCoCo Maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,6 +221,7 @@
 		<groovy-maven-plugin.version>1.5</groovy-maven-plugin.version>
 		<imagej-maven-plugin.version>0.7.1</imagej-maven-plugin.version>
 		<javafx-maven-plugin.version>8.8.3</javafx-maven-plugin.version>
+		<jacoco-maven-plugin.version>0.8.2</jacoco-maven-plugin.version>
 		<license-maven-plugin.version>1.16</license-maven-plugin.version>
 		<maven-graph-plugin.version>1.39</maven-graph-plugin.version>
 		<nar-maven-plugin.version>3.5.2</nar-maven-plugin.version>
@@ -557,6 +558,17 @@
 							<format>xml</format>
 						</formats>
 					</configuration>
+				</plugin>
+
+				<!--
+				JaCoCo Maven plugin -
+				https://www.jacoco.org/jacoco/trunk/doc/maven.html
+				This plugin measures code coverage of tests.
+				-->
+				<plugin>
+					<groupId>org.jacoco</groupId>
+					<artifactId>jacoco-maven-plugin</artifactId>
+					<version>${jacoco-maven-plugin.version}</version>
 				</plugin>
 
 				<!-- Exec Maven plugin -

--- a/pom.xml
+++ b/pom.xml
@@ -200,10 +200,10 @@
 		<maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
 		<maven-enforcer-plugin.version>1.4.1</maven-enforcer-plugin.version>
 		<maven-failsafe-plugin.version>2.21.0</maven-failsafe-plugin.version>
-		<maven-jar-plugin.version>3.1.0</maven-jar-plugin.version>
+		<maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
 		<maven-install-plugin.version>2.5.2</maven-install-plugin.version>
 		<maven-invoker-plugin.version>3.1.0</maven-invoker-plugin.version>
-		<maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
+		<maven-jar-plugin.version>3.1.0</maven-jar-plugin.version>
 		<maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>
 		<maven-plugin-plugin.version>3.5.2</maven-plugin-plugin.version>
 		<maven-release-plugin.version>2.5.3</maven-release-plugin.version>
@@ -216,17 +216,17 @@
 		<build-helper-maven-plugin.version>3.0.0</build-helper-maven-plugin.version>
 		<buildnumber-maven-plugin.version>1.4</buildnumber-maven-plugin.version>
 		<cobertura-maven-plugin.version>2.7</cobertura-maven-plugin.version>
-		<exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
-		<license-maven-plugin.version>1.16</license-maven-plugin.version>
-		<versions-maven-plugin.version>2.5</versions-maven-plugin.version>
-		<maven-graph-plugin.version>1.39</maven-graph-plugin.version>
-		<javafx-maven-plugin.version>8.8.3</javafx-maven-plugin.version>
-		<nar-maven-plugin.version>3.5.2</nar-maven-plugin.version>
-		<scijava-maven-plugin.version>1.1.0</scijava-maven-plugin.version>
-		<imagej-maven-plugin.version>0.7.1</imagej-maven-plugin.version>
-		<groovy-maven-plugin.version>1.5</groovy-maven-plugin.version>
-		<nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
 		<dokka-maven-plugin.version>0.9.16</dokka-maven-plugin.version>
+		<exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
+		<groovy-maven-plugin.version>1.5</groovy-maven-plugin.version>
+		<imagej-maven-plugin.version>0.7.1</imagej-maven-plugin.version>
+		<javafx-maven-plugin.version>8.8.3</javafx-maven-plugin.version>
+		<license-maven-plugin.version>1.16</license-maven-plugin.version>
+		<maven-graph-plugin.version>1.39</maven-graph-plugin.version>
+		<nar-maven-plugin.version>3.5.2</nar-maven-plugin.version>
+		<nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
+		<scijava-maven-plugin.version>1.1.0</scijava-maven-plugin.version>
+		<versions-maven-plugin.version>2.5</versions-maven-plugin.version>
 
 		<!-- Plugin dependencies -->
 		<extra-enforcer-rules.version>1.0-beta-9</extra-enforcer-rules.version>


### PR DESCRIPTION
This adds another code coverage plugin, used by some (potential) downstream projects to test code coverage, see https://github.com/aherbert/gdsc-super/issues/1.