### PR TITLE
Append argLine arguments instead of overriding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -495,7 +495,7 @@
 					own property 'scijava.surefire.args' to specify those options.
 					-->
 					<configuration>
-						<argLine>-Xms512m -Xmx512m -Dapple.awt.UIElement="true" ${scijava.surefire.args}</argLine>
+						<argLine>@{argLine} -Xms512m -Xmx512m -Dapple.awt.UIElement="true" ${scijava.surefire.args}</argLine>
 					</configuration>
 				</plugin>
 


### PR DESCRIPTION
This change in the configuration of maven-surefire-plugin is required to work correctly with JaCoCo usage in downstream projects.

After a release of `pom-scijava-base-7.0.0` (and `pom-scijava-27.0.0` inheriting from it), JaCoCo code coverage tests can then be added to any downstream project by adding the following to its `pom.xml`:

```xml
<build>
	<plugins>
		<plugin>
			<groupId>org.jacoco</groupId>
			<artifactId>jacoco-maven-plugin</artifactId>
			<executions>
				<execution>
					<id>jacoco-initialize</id>
					<goals>
						<goal>prepare-agent</goal>
					</goals>
				</execution>
				<execution>
					<id>jacoco-site</id>
					<phase>package</phase>
					<goals>
						<goal>report</goal>
					</goals>
				</execution>
			</executions>
		</plugin>
	</plugins>
</build>
```
