### PR TITLE
Update the Maven dependency plugin to version 3.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,7 @@
 		<maven-assembly-plugin.version>3.1.1</maven-assembly-plugin.version>
 		<maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
 		<maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-		<maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
+		<maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
 		<maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
 		<maven-enforcer-plugin.version>1.4.1</maven-enforcer-plugin.version>
 		<maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>


### PR DESCRIPTION
This version fixes a bug related to analyzing the dependencies of Java
11 projects. Prior to the fix, running mvn dependency:analyze on a Java
11 project would cause an ERROR, since the plugin could not read the
classes. See (this bug report)[https://issues.apache.org/jira/browse/MDEP-613].