### PR TITLE
Build on jdk8plus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.scijava</groupId>
 	<artifactId>pom-scijava-base</artifactId>
-	<version>11.3.0-SNAPSHOT</version>
+	<version>12.0.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>SciJava Base POM</name>
@@ -161,10 +161,10 @@
 		<license.copyrightOwners>N/A</license.copyrightOwners>
 
 		<!-- Compiler configuration. -->
-		<scijava.jvm.version>1.8</scijava.jvm.version>
+		<scijava.jvm.version>8</scijava.jvm.version>
 		<scijava.jvm.test.version>${scijava.jvm.version}</scijava.jvm.test.version>
 		<!-- NB: 1.8.0_101 is needed for SciJava Maven repository HTTPS support. -->
-		<scijava.jvm.build.version>[1.8.0-101,1.8.9999]</scijava.jvm.build.version>
+		<scijava.jvm.build.version>[1.8.0-101,)</scijava.jvm.build.version>
 		<maven.compiler.source>${scijava.jvm.version}</maven.compiler.source>
 		<maven.compiler.target>${scijava.jvm.version}</maven.compiler.target>
 		<maven.compiler.testSource>${scijava.jvm.test.version}</maven.compiler.testSource>
@@ -2013,6 +2013,15 @@
 			</activation>
 			<properties>
 				<scijava.platform.bits>32</scijava.platform.bits>
+			</properties>
+		</profile>
+		<profile>
+			<id>java-9</id>
+			<activation>
+				<jdk>[9,)</jdk>
+			</activation>
+			<properties>
+				<maven.compiler.release>${scijava.jvm.version}</maven.compiler.release>
 			</properties>
 		</profile>
 	</profiles>


### PR DESCRIPTION
This PR addresses all issues raised in the closed PR https://github.com/scijava/pom-scijava-base/pull/22 achieving the same objective.

Explanation:Cross-compilation with the javac `--target` flag is unsafe without also providing the corresponding standard library via `-bootclasspath` which changes to `--system` in JDK >9 and is difficult to use, see

https://bugs.openjdk.java.net/browse/JDK-8058150

However, JDKs >=9 also provide the `--release` flag which bundles target platform and target standard library specification, see

https://mail.openjdk.java.net/pipermail/jdk9-dev/2015-July/002414.html

This PR sets the corresponding property for the maven.compiler plugin and unsets it when JDK 1.8 is used for the build, because JDK 1.8 does not understand this flag.