### PR TITLE
Bump Kotlin to 1.4.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -274,7 +274,7 @@
 
 		<!-- Plugin dependencies -->
 		<extra-enforcer-rules.version>1.2</extra-enforcer-rules.version>
-		<kotlin.version>1.4-M2</kotlin.version>
+		<kotlin.version>1.4.10</kotlin.version>
 		<revapi-java.version>0.20.2</revapi-java.version>
 		<scijava-coding-style.version>2.0.0</scijava-coding-style.version>
 		<velocity.version>1.7</velocity.version>


### PR DESCRIPTION
This PR bumps Kotlin from 1.4-M2 to 1.4.10.