### PR TITLE
Add support for `arm64` i.e. M1 mac

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2019,6 +2019,17 @@
 			</properties>
 		</profile>
 		<profile>
+			<id>scijava-platform-arm64</id>
+			<activation>
+				<os>
+					<arch>arm64</arch>
+				</os>
+			</activation>
+			<properties>
+				<scijava.platform.bits>64</scijava.platform.bits>
+			</properties>
+		</profile>
+		<profile>
 			<id>scijava-platform-x86_64</id>
 			<activation>
 				<os>


### PR DESCRIPTION
See discussion here https://forum.image.sc/t/how-does-scijava-platform-bits-expand-issues-on-m1-mac/62238

At the moment, the `pom.xml` only appears to support Intel 32bit/64bit and AMD 64 bit. This PR adds support for ARM 64bit which is what it used by Apple Silicon/M1 Mac.

I _think_ this is all that is required but let me know if I need to make changes elsewhere