### PR TITLE
Add therapi-runtime-javadoc-scribe To Maven Compiler Plugin Annotation Processors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -225,11 +225,12 @@
 		<!--
 		NB: The javadoc.runtimeAccessPackages property allows downstream
 		projects to identify directories whose Javadoc should be made available
-		at runtime. By default, Javadoc is not available for any packages.
-		Downstream projects can identify a comma-delineated set of packages
-		to make those packages' Javadoc available. To retain some packages,
-		override the javadoc.runtimeAccessPackages property in your POM
-		with something like this:
+		at runtime. This javadoc can then be accessed through
+		therapi-runtime-javadoc. By default, Javadoc is not available for any
+		packages. Downstream projects can identify a comma-delineated set of
+		packages to make those packages' Javadoc available. To retain some
+		packages, override the javadoc.runtimeAccessPackages property in your
+		POM with something like this:
 		<javadoc.runtimeAccessPackages>com.example.foo,com.example.bar</javadoc.runtimeAccessPackages>
 		To retain all packages, override the javadoc.runtimeAccessPackages
 		property in your POM with:


### PR DESCRIPTION
This PR introduces [therapi-runtime-javadoc](https://github.com/dnault/therapi-runtime-javadoc) as an **opt-in** annotation processor for javadoc retention. It is added as a dependency of the Maven Compiler Plugin, producing JSON files for each .java file in the packages passed to it. The passed packages are controlled with the `javadoc.retainPackages` property, also added in this PR. This property is initialized to pass no packages to the processor.

Downstream projects can override the property to pass some or all of their packages to the processor.
* To pass some packages, write them as a comma-delineated list: `<javadoc.retainPackages>com.example.foo,com.example.bar</javadoc.retainPackages>`
* To pass all packages, leave the property empty: `<javadoc.retainPackages/>`